### PR TITLE
BUG: add ssl_host_name setting for https urls and parsing HTTP AUTH credentials from URI on Request instance creating.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -588,6 +588,11 @@ class Request extends \Swlib\Http\Request
             'timeout' => (($this->_form_flag & self::FROM_REDIRECT) && $this->_timeout) ? $this->_timeout : $this->getTimeout(),
             'keep_alive' => $this->getKeepAlive(),
         ];
+
+        if($this->ssl) {
+            $settings['ssl_host_name'] = $this->uri->getHost();
+        }
+
         $settings += $this->getProxy();
 
         if (!empty($ca_file = $this->getCAFile())) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -96,6 +96,7 @@ class Request extends \Swlib\Http\Request
     {
         parent::__construct($method, $uri, $headers, $body);
         $this->__cookiesInitialization(true);
+        $this->initBasicAuth();
     }
 
     public function getExceptionReport(): int
@@ -113,6 +114,17 @@ class Request extends \Swlib\Http\Request
     public function isWaiting(): bool
     {
         return $this->_status === self::STATUS_WAITING;
+    }
+
+    protected function initBasicAuth()
+    {
+        $userInfo = $this->getUri()->getUserInfo();
+        if($userInfo) {
+            $userInfo = explode(':', $userInfo);
+            $username = $userInfo[0];
+            $password = $userInfo[1] ?? null;
+            $this->withBasicAuth($username, $password);
+        }
     }
 
     protected function getConnectionTarget(): array

--- a/tests/SaberTest.php
+++ b/tests/SaberTest.php
@@ -247,6 +247,13 @@ class SaberTest extends TestCase
         $this->assertEquals(true, $res->getSuccess(), (string)$res);
     }
 
+    public function testRetryAndAuthWithUserInfoInURI()
+    {
+        $uri = 'http://foo:bar@www.httpbin.org/basic-auth/foo/bar';
+        $res = SaberGM::get($uri);
+        $this->assertEquals(true, $res->getSuccess(), (string)$res);
+    }
+
     public function testIconv()
     {
         $this->assertContains(

--- a/tests/SaberTest.php
+++ b/tests/SaberTest.php
@@ -247,10 +247,24 @@ class SaberTest extends TestCase
         $this->assertEquals(true, $res->getSuccess(), (string)$res);
     }
 
-    public function testRetryAndAuthWithUserInfoInURI()
+    public function testAuthWithUserInfoInURI()
     {
         $uri = 'http://foo:bar@www.httpbin.org/basic-auth/foo/bar';
         $res = SaberGM::get($uri);
+        $this->assertEquals(true, $res->getSuccess(), (string)$res);
+    }
+
+    public function testAuthOverrideUserInfoInURI()
+    {
+        $uri = 'http://doo:zar@www.httpbin.org/basic-auth/foo/bar';
+        $res = SaberGM::get($uri,
+            [
+            'before' => function (Request $request) {
+                $request->withBasicAuth('foo', 'bar');
+            }
+            ]
+        );
+
         $this->assertEquals(true, $res->getSuccess(), (string)$res);
     }
 


### PR DESCRIPTION
During production use i've found an issue with connection to https://https://uds.hasene.online. Request failed with warning:

`WARNING	swSSL_connect: SSL_connect(fd=9) failed. Error: (null)[1|0].`

After investigation fix https://github.com/swoole/swoole-src/commit/77876aad4b423fd2538152d86ce7f63fd075fe71 i've added 'ssl_host_name' with host name for SSL request.

Also added parsing HTTP AUTH credentials from URI on Request instance creating.

PHP version: 7.3.3

Swoole:

Swoole => enabled
Author => Swoole Team <team@swoole.com>
Version => 4.3.1
Built => Mar 27 2019 15:38:16
coroutine => enabled
kqueue => enabled
rwlock => enabled
openssl => OpenSSL 1.0.2r  26 Feb 2019
http2 => enabled
pcre => enabled
zlib => enabled
brotli => enabled
async_redis => enabled



