### PR TITLE
【Fix】\Swlib\Saber\Request::SSL_AUTO 判断HTTPS的方法不正确

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -123,7 +123,7 @@ class Request extends \Swlib\Http\Request
         }
         $port = $this->uri->getRealPort();
         $ssl = $this->getSSL();
-        $ssl = ($ssl === self::SSL_AUTO) ? $port === 443 : (bool)$ssl;
+        $ssl = ($ssl === self::SSL_AUTO) ? ('https' === $this->uri->getScheme()) : (bool)$ssl;
 
         return ['host' => $host, 'port' => $port, 'ssl' => $ssl];
     }


### PR DESCRIPTION
https://github.com/swlib/saber/blob/1188d0a67d18430d5c1a11f8dcdc135852fc1e31/src/Request.php#L126

不应该用端口来判断是否是https还是http，

- 一来，443端口也可以运行http程序，https也可以运行在非443端口，AUTO应该且必须根据scheme来决定，

- 二来，有些web服务器在443端口同时提供http和https ，但是要求某些api必须通过特定的scheme调用，这会会导致saber的一些判断出现问题 。

```bash
curl --request POST   --url 'http://eco.taobao.com/router/rest?app_key=123456&method=taobao.top.secret.get&v=2.0'
curl --request POST   --url 'https://eco.taobao.com/router/rest?app_key=123456&method=taobao.top.secret.get&v=2.0'
```
